### PR TITLE
Fix metadata handling for SystemOperationMetadata

### DIFF
--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -266,6 +266,7 @@ func (s *ConstructionAPIService) ConstructionPayloads(
 			s := operations.StakeOperationMetadata{}
 			s.SetMeta(tmpOP)
 			instructions = append(instructions, (s.ToInstructions(tmpOP.Type))...)
+			break
 		default:
 			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("Operation not implemented for construction"))
 		}

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -262,6 +262,10 @@ func (s *ConstructionAPIService) ConstructionPayloads(
 			s.SetMeta(tmpOP)
 			instructions = append(instructions, (s.ToInstructions(tmpOP.Type))...)
 			break
+		case "Stake":
+			s := operations.StakeOperationMetadata{}
+			s.SetMeta(tmpOP)
+			instructions = append(instructions, (s.ToInstructions(tmpOP.Type))...)
 		default:
 			return nil, wrapErr(ErrUnableToParseIntermediateResult, fmt.Errorf("Operation not implemented for construction"))
 		}

--- a/solana/client.go
+++ b/solana/client.go
@@ -124,7 +124,7 @@ func (ec *Client) Balance(
 	block *RosettaTypes.PartialBlockIdentifier,
 ) (*RosettaTypes.AccountBalanceResponse, error) {
 
-	var symbols []string
+	//var symbols []string
 	if block != nil {
 		return nil, fmt.Errorf("block hash balance not supported")
 	}
@@ -144,26 +144,26 @@ func (ec *Client) Balance(
 		Metadata: nil,
 	}
 
-	tokenAccs, err := ec.Rpc.GetTokenAccountsByOwner(ctx, account.Address)
-
-	if err == nil {
-		for _, tokenAcc := range tokenAccs {
-			symbol := tokenAcc.Account.Data.Parsed.Info.Mint
-			b := &RosettaTypes.Amount{
-				Value: tokenAcc.Account.Data.Parsed.Info.TokenAmount.Amount,
-				Currency: &RosettaTypes.Currency{
-					Symbol:   symbol,
-					Decimals: tokenAcc.Account.Data.Parsed.Info.TokenAmount.Decimals,
-					Metadata: nil,
-				},
-				Metadata: nil,
-			}
-			balances = append(balances, b)
-		}
-	}
-	if len(symbols) == 0 || Contains(symbols, Symbol) {
-		balances = append(balances, nativeBalance)
-	}
+	//tokenAccs, err := ec.Rpc.GetTokenAccountsByOwner(ctx, account.Address)
+	//
+	//if err == nil {
+	//	for _, tokenAcc := range tokenAccs {
+	//		symbol := tokenAcc.Account.Data.Parsed.Info.Mint
+	//		b := &RosettaTypes.Amount{
+	//			Value: tokenAcc.Account.Data.Parsed.Info.TokenAmount.Amount,
+	//			Currency: &RosettaTypes.Currency{
+	//				Symbol:   symbol,
+	//				Decimals: tokenAcc.Account.Data.Parsed.Info.TokenAmount.Decimals,
+	//				Metadata: nil,
+	//			},
+	//			Metadata: nil,
+	//		}
+	//		balances = append(balances, b)
+	//	}
+	//}
+	//if len(symbols) == 0 || Contains(symbols, Symbol) {
+	balances = append(balances, nativeBalance)
+	//}
 	slot, err := ec.Rpc.GetSlot(ctx)
 
 	return &RosettaTypes.AccountBalanceResponse{

--- a/solana/operations/stake.go
+++ b/solana/operations/stake.go
@@ -1,0 +1,133 @@
+package operations
+
+import (
+	"encoding/json"
+	types "github.com/coinbase/rosetta-sdk-go/types"
+	solanago "github.com/imerkle/rosetta-solana-go/solana"
+	"github.com/portto/solana-go-sdk/common"
+	"github.com/portto/solana-go-sdk/stakeprog"
+	"github.com/portto/solana-go-sdk/sysprog"
+	solPTypes "github.com/portto/solana-go-sdk/types"
+	"log"
+)
+
+type StakeOperationMetadata struct {
+	Source                 string `json:"source,omitempty"`
+	Stake                  string `json:"stake,omitempty"`
+	Lamports               uint64 `json:"lamports,omitempty"`
+	Staker                 string `json:"staker,omitempty"`
+	Withdrawer             string `json:"withdrawer,omitempty"`
+	WithdrawDestination    string `json:"withdrawDestination,omitempty"`
+	LockupUnixTimestamp    int64  `json:"lockupUnixTimestamp,omitempty"`
+	LockupEpoch            uint64 `json:"lockupEpoch,omitempty"`
+	LockupCustodian        string `json:"lockupCustodian,omitempty"`
+	VoteAccount            string `json:"voteAccount,omitempty"`
+	MergeDestination       string `json:"mergeDestination,omitempty"`
+	SplitDestination       string `json:"splitDestination,omitempty"`
+	Authority              string `json:"authority,omitempty"`
+	NewAuthority           string `json:"newAuthority,omitempty"`
+	StakeAuthorizationType uint32 `json:"stakeAuthorizationType,omitempty"`
+}
+
+func (x *StakeOperationMetadata) SetMeta(op *types.Operation) {
+	jsonString, _ := json.Marshal(op.Metadata)
+	json.Unmarshal(jsonString, &x)
+	if x.Lamports == 0 && op.Amount != nil {
+		x.Lamports = solanago.ValueToBaseAmount(op.Amount.Value)
+	}
+	if x.Source == "" && op.Account != nil {
+		x.Source = op.Account.Address
+	}
+	if x.Staker == "" && op.Account != nil {
+		x.Staker = op.Account.Address
+	}
+	if x.Withdrawer == "" && op.Account != nil {
+		x.Withdrawer = op.Account.Address
+	}
+}
+func (x *StakeOperationMetadata) ToInstructions(opType string) []solPTypes.Instruction {
+
+	var ins []solPTypes.Instruction
+	switch opType {
+	case solanago.Stake__CreateStakeAccount:
+		ins = addCreateStakeAccountIns(ins, x)
+		break
+	case solanago.Stake__DelegateStake:
+		ins = addDelegateStakeIns(ins, x)
+		break
+	case solanago.Stake__CreateStakeAndDelegate:
+		ins = addCreateStakeAccountIns(ins, x)
+		ins = addDelegateStakeIns(ins, x)
+		break
+	case solanago.Stake__DeactivateStake:
+		ins = append(ins, stakeprog.Deactivate(p(x.Stake), p(x.Staker)))
+		break
+	case solanago.Stake__WithdrawStake:
+		ins = append(ins,
+			stakeprog.Withdraw(
+				p(x.Stake),
+				p(x.Withdrawer),
+				p(x.WithdrawDestination),
+				x.Lamports,
+				p(x.LockupCustodian)))
+		break
+	case solanago.Stake__Merge:
+		ins = append(ins,
+			stakeprog.Merge(
+				p(x.MergeDestination),
+				p(x.Stake),
+				p(x.Staker)))
+		break
+	case solanago.Stake__Split:
+		ins = append(ins,
+			stakeprog.Split(
+				p(x.Stake),
+				p(x.Staker),
+				p(x.SplitDestination),
+				x.Lamports))
+		break
+	case solanago.Stake__Authorize:
+		ins = append(ins,
+			stakeprog.Authorize(
+				p(x.Stake),
+				p(x.Authority),
+				p(x.NewAuthority),
+				stakeprog.StakeAuthorizationType(x.StakeAuthorizationType),
+				p(x.LockupCustodian)))
+		break
+	}
+
+	log.Printf("---------- Request ----------")
+	log.Printf("x: %+v\n", x)
+	log.Printf("---------- Instruction ----------")
+	log.Printf("ins: %+v\n", ins)
+
+	return ins
+}
+
+func addCreateStakeAccountIns(ins []solPTypes.Instruction, x *StakeOperationMetadata) []solPTypes.Instruction {
+	ins = append(ins,
+		sysprog.CreateAccount(
+			p(x.Source),
+			p(x.Stake),
+			common.StakeProgramID,
+			x.Lamports,
+			stakeprog.AccountSize))
+	ins = append(ins,
+		stakeprog.Initialize(
+			p(x.Stake),
+			stakeprog.Authorized{
+				Staker:     p(x.Staker),
+				Withdrawer: p(x.Withdrawer),
+			},
+			stakeprog.Lockup{
+				UnixTimestamp: x.LockupUnixTimestamp,
+				Epoch:         x.LockupEpoch,
+				Cusodian:      p(x.LockupCustodian),
+			}))
+	return ins
+}
+
+func addDelegateStakeIns(ins []solPTypes.Instruction, x *StakeOperationMetadata) []solPTypes.Instruction {
+	return append(ins, stakeprog.DelegateStake(p(x.Stake), p(x.Staker), p(x.VoteAccount)))
+}

--- a/solana/operations/stake.go
+++ b/solana/operations/stake.go
@@ -8,7 +8,6 @@ import (
 	"github.com/portto/solana-go-sdk/stakeprog"
 	"github.com/portto/solana-go-sdk/sysprog"
 	solPTypes "github.com/portto/solana-go-sdk/types"
-	"log"
 )
 
 type StakeOperationMetadata struct {
@@ -96,11 +95,6 @@ func (x *StakeOperationMetadata) ToInstructions(opType string) []solPTypes.Instr
 				p(x.LockupCustodian)))
 		break
 	}
-
-	log.Printf("---------- Request ----------")
-	log.Printf("x: %+v\n", x)
-	log.Printf("---------- Instruction ----------")
-	log.Printf("ins: %+v\n", ins)
 
 	return ins
 }

--- a/solana/operations/system.go
+++ b/solana/operations/system.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"encoding/json"
-
 	"github.com/coinbase/rosetta-sdk-go/types"
 	solanago "github.com/imerkle/rosetta-solana-go/solana"
 	"github.com/portto/solana-go-sdk/common"
@@ -21,6 +20,7 @@ type SystemOperationMetadata struct {
 
 func (x *SystemOperationMetadata) SetMeta(op *types.Operation) {
 	jsonString, _ := json.Marshal(op.Metadata)
+	json.Unmarshal(jsonString, &x)
 	if x.Lamports == 0 {
 		x.Lamports = solanago.ValueToBaseAmount(op.Amount.Value)
 	}
@@ -30,7 +30,6 @@ func (x *SystemOperationMetadata) SetMeta(op *types.Operation) {
 	if x.Authority == "" {
 		x.Authority = x.Source
 	}
-	json.Unmarshal(jsonString, &x)
 }
 func (x *SystemOperationMetadata) ToInstructions(opType string) []solPTypes.Instruction {
 

--- a/solana/types.go
+++ b/solana/types.go
@@ -101,6 +101,14 @@ const (
 	SplToken__TransferWithSystem      = "SplToken__TransferWithSystem"
 	SplAssociatedTokenAccount__Create = "SplAssociatedTokenAccount__Create"
 	Unknown                           = "Unknown"
+	Stake__CreateStakeAccount         = "Stake__CreateStakeAccount"
+	Stake__DelegateStake              = "Stake__DelegateStake"
+	Stake__CreateStakeAndDelegate     = "Stake__CreateStakeAndDelegate"
+	Stake__DeactivateStake            = "Stake__DeactivateStake"
+	Stake__WithdrawStake              = "Stake__WithdrawStake"
+	Stake__Merge                      = "Stake__Merge"
+	Stake__Split                      = "Stake__Split"
+	Stake__Authorize                  = "Stake__Authorize"
 )
 
 var (
@@ -156,6 +164,14 @@ var (
 		SplToken__TransferNew,
 		SplToken__TransferWithSystem,
 		SplAssociatedTokenAccount__Create,
+		Stake__CreateStakeAccount,
+		Stake__DelegateStake,
+		Stake__CreateStakeAndDelegate,
+		Stake__DeactivateStake,
+		Stake__WithdrawStake,
+		Stake__Merge,
+		Stake__Split,
+		Stake__Authorize,
 		Unknown,
 	}
 


### PR DESCRIPTION
op.Metadata was only unmarshalled AFTER all the checks/fallbacks were evaluated.
So all the checks were true, the fallbacks evaluated but at the end overwritten again.
Also it made setting op.Amount.Value and op.Account.Address mandatory to not have an exception